### PR TITLE
fix for: cursorTo / clearLine is not a function

### DIFF
--- a/lib/Bar.js
+++ b/lib/Bar.js
@@ -1,3 +1,5 @@
+var readline = require("readline");
+
 // Progress-Bar constructor
 function Bar(options){
     // options set ?
@@ -87,13 +89,13 @@ Bar.prototype.render = function(){
     // string changed ? only trigger redraw on change!
     if (this.lastDrawnString != s){
         // set cursor to start of line
-        this.stream.cursorTo(0);
+        readline.cursorTo(this.stream, 0);
 
         // write output
         this.stream.write(s);
 
         // clear to the right from cursor
-        this.stream.clearLine(1);
+        readline.clearLine(this.stream, 1);
 
         // store string
         this.lastDrawnString = s;


### PR DESCRIPTION
I ran into a problem when running nodemcu-tool (which is great!) via gulp and gulp-shell. This fixed it. See also [this SO question](http://stackoverflow.com/questions/34570452/node-js-stdout-clearline-and-cursorto-functions).