### PR TITLE
Fix typo in default format

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,13 @@ The progressbar can be customized by using the following build-in placeholders. 
 #### Example ####
 
 ```
-progess [{bar}] {percentage}% | ETA: {eta}s | {value}/{total}
+progress [{bar}] {percentage}% | ETA: {eta}s | {value}/{total}
 ```
 
 is rendered as
 
 ```
-progess [========================================] 100% | ETA: 0s | 200/200
+progress [========================================] 100% | ETA: 0s | 200/200
 ```
 
 ### Options ###

--- a/lib/Bar.js
+++ b/lib/Bar.js
@@ -37,7 +37,7 @@ function Bar(options){
     this.barIncompleteString = (new Array(this.barsize + 1 ).join(options.barIncompleteChar || '-'));
 
     // the bar format
-    this.format = options.format || 'progess [{bar}] {percentage}% | ETA: {eta}s | {value}/{total}';
+    this.format = options.format || 'progress [{bar}] {percentage}% | ETA: {eta}s | {value}/{total}';
 
     // start time (used for eta calculation)
     this.startTime = null;


### PR DESCRIPTION
Currently shows `progess` - this should be `progress`