### PR TITLE
Use a buffer of recent updates to determine ETA

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ progess [========================================] 100% | ETA: 0s | 200/200
 - `barCompleteString` (type:char) - character to use as "complete" indicator in the bar (default: "=")
 - `barIncompleteString` (type:char) - character to use as "incomplete" indicator in the bar (default: "-")
 - `hideCursor` (type:boolean) - hide the cursor during progress operation; restored on complete (default: false)
+- `etaBuffer` (type:int) - number of updates with which to calculate the eta; higher numbers give a more stable eta (default: 10)
 
 #### Example ####
 

--- a/lib/Bar.js
+++ b/lib/Bar.js
@@ -174,10 +174,12 @@ Bar.prototype.update = function(current){
     // update value
     this.value = current;
 
-    this.calculateETA(current);
+    this.eta.valueBuffer.push(current);
+    this.eta.timeBuffer.push(Date.now());
 
     // throttle the update or force update ?
     if (this.lastRedraw + this.throttleTime < Date.now()){
+        this.calculateETA();
         this.render();
     }
 };
@@ -197,11 +199,7 @@ Bar.prototype.stopTimer = function(){
 };
 
 // internal - eta calculation
-Bar.prototype.calculateETA = function(current){
-
-
-    this.eta.valueBuffer.push(current);
-    this.eta.timeBuffer.push(Date.now());
+Bar.prototype.calculateETA = function(){
 
     var l = this.eta.valueBuffer.length;
     var buffer = Math.min(this.etaBuffer, l);
@@ -213,7 +211,7 @@ Bar.prototype.calculateETA = function(current){
     var vt_rate = v_diff/t_diff;
 
     // remaining
-    var remaining = this.total-current;
+    var remaining = this.total-this.value;
 
     // eq: vt_rate *x = total
     var eta = remaining/vt_rate/1000;

--- a/lib/Bar.js
+++ b/lib/Bar.js
@@ -45,6 +45,9 @@ function Bar(options){
     // last update time
     this.lastRedraw = Date.now();
 
+    // the number of results to average ETA over
+    this.etaBuffer = options.etaBuffer || 10;
+
     // eta buffer
     this.eta = {};
 };
@@ -134,8 +137,8 @@ Bar.prototype.start = function(total, startValue){
 
     // initialize eta buffer
     this.eta = {
-        lastValue: 0,
-        lastTime: this.startTime,
+        valueBuffer: [this.value],
+        timeBuffer: [this.startTime],
         time: null
     };
 };
@@ -195,9 +198,16 @@ Bar.prototype.stopTimer = function(){
 
 // internal - eta calculation
 Bar.prototype.calculateETA = function(current){
-    // calc the difference
-    var v_diff = current-this.eta.lastValue;
-    var t_diff = (Date.now() - this.eta.lastTime);
+
+
+    this.eta.valueBuffer.push(current);
+    this.eta.timeBuffer.push(Date.now());
+
+    var l = this.eta.valueBuffer.length;
+    var buffer = Math.min(this.etaBuffer, l);
+
+    var v_diff = this.eta.valueBuffer[l - 1] - this.eta.valueBuffer[l - buffer];
+    var t_diff = this.eta.timeBuffer[l - 1] - this.eta.timeBuffer[l - buffer];
 
     // get progress per ms
     var vt_rate = v_diff/t_diff;
@@ -208,12 +218,11 @@ Bar.prototype.calculateETA = function(current){
     // eq: vt_rate *x = total
     var eta = remaining/vt_rate/1000;
 
-    // store the value
     this.eta = {
-        lastValue: current,
-        lastTime: Date.now(),
+        valueBuffer: this.eta.valueBuffer.slice(-this.etaBuffer),
+        timeBuffer: this.eta.timeBuffer.slice(-this.etaBuffer),
         time: Math.ceil(eta)
-    };
+    }
 };
 
 module.exports = Bar;


### PR DESCRIPTION
When eta is calculated only based on the most recent update then it fluctuates wildly to the point of being totally unusable - especially when iterating over a large set, and sending an update event on every iteration.

Instead save a buffer of the values and timestamps of all updates and calculate the rate of change - and hence eta - based on the moving average of the last N updates based on the option passed.

This provides a much more stable eta value that should also be more accurate since it is based on a larger spread of data.