### PR TITLE
Add output time formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ The progressbar can be customized by using the following build-in placeholders. 
 - `{value}` - the current value set by last `update()` call
 - `{eta}` - expected time of accomplishment in seconds
 - `{duration}` - elapsed time in seconds
+- `{eta_formatted}` - expected time of accomplishment formatted into appropriate units
+- `{duration_formatted}` - elapsed time formatted into appropriate units
 
 #### Example ####
 

--- a/lib/Bar.js
+++ b/lib/Bar.js
@@ -74,9 +74,11 @@ Bar.prototype.render = function(){
 
     // calculate elapsed time
     var elapsedTime = Math.round((Date.now() - this.startTime)/1000);
+    var elapsedTimef = this.formatTime(elapsedTime);
 
     // calculate eta
     var eta = this.eta.time;
+    var etaf = this.formatTime(eta, 5);
 
     // assign placeholder tokens
     s = s.replace(/\{bar}/gi, b)
@@ -84,7 +86,9 @@ Bar.prototype.render = function(){
         .replace(/\{total}/gi, this.total + '')
         .replace(/\{value}/gi, this.value + '')
         .replace(/\{eta}/gi, eta + '')
-        .replace(/\{duration}/gi, elapsedTime + '');
+        .replace(/\{eta_formatted}/gi, etaf + '')
+        .replace(/\{duration}/gi, elapsedTime + '')
+        .replace(/\{duration_formatted}/gi, elapsedTimef + '');
 
     // string changed ? only trigger redraw on change!
     if (this.lastDrawnString != s){
@@ -107,6 +111,26 @@ Bar.prototype.render = function(){
     // next update
     this.timer = setTimeout(this.render.bind(this), this.throttleTime*2);
 };
+
+// format a number of seconds into hours and minutes as appropriate
+Bar.prototype.formatTime = function (t, roundTo) {
+    var round = function (input) {
+        if (roundTo) {
+            return roundTo * Math.round(input / roundTo);
+        } else {
+            return input
+        }
+    }
+    if (t > 3600) {
+        return Math.floor(t / 3600) + 'h' + round((t % 3600) / 60) + 'm';
+    } else if (t > 60) {
+        return Math.floor(t / 60) + 'm' + round((t % 60)) + 's';
+    } else if (t > 10) {
+        return round(t) + 's';
+    } else {
+        return t + 's';
+    }
+}
 
 // start the progress bar
 Bar.prototype.start = function(total, startValue){


### PR DESCRIPTION
Allows a duration or eta to be formatted as hours/minutes for longer running tasks instead of always outputting as seconds. This means that an eta of `234s` is instead displayed as `3m55s`, which is a lot more easily parseable.