### PR TITLE
Fix frames-per-second parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ progess [========================================] 100% | ETA: 0s | 200/200
 ### Options ###
 
 - `format` (type:string) - progress bar output format @see format section
-- `fps` (type:int) - the maximum update rate
+- `fps` (type:float) - the maximum update rate (default: 10)
 - `stream` (type:stream) - output stream to use (default: `process.stderr`)
 - `clearOnComplete` (type:boolean) - clear the progress bar on complete / `stop()` call (default: false)
 - `barsize` (type:int) - the length of the progress bar in chars (default: 40)

--- a/lib/Bar.js
+++ b/lib/Bar.js
@@ -15,7 +15,7 @@ function Bar(options){
     this.total = 100;
 
     // the max update rate in fps (redraw will only triggered on value change)
-    this.throttleTime = (options.fps || 10)/1000;
+    this.throttleTime = 1000 / (options.fps || 10);
 
     // the output stream to write on
     this.stream = options.stream || process.stderr;


### PR DESCRIPTION
The calculation of the throttle time based on `fps` option was the wrong way round so that *decreasing* the fps (which *should* result in fewer renders) actually caused the render rate to increase.

A `fps` of 10 should result in a timeout value of 100ms, but as the code was previously it resulted in a timeout of 0.01ms, which effectively meant that there was no throttling.