### PR TITLE
Add option to automatically `stop` on completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ progress [========================================] 100% | ETA: 0s | 200/200
 - `format` (type:string) - progress bar output format @see format section
 - `fps` (type:float) - the maximum update rate (default: 10)
 - `stream` (type:stream) - output stream to use (default: `process.stderr`)
+- `stopOnComplete` (type:boolean) - automatically call `stop()` when the value reaches the total (default: false)
 - `clearOnComplete` (type:boolean) - clear the progress bar on complete / `stop()` call (default: false)
 - `barsize` (type:int) - the length of the progress bar in chars (default: 40)
 - `barCompleteString` (type:char) - character to use as "complete" indicator in the bar (default: "=")

--- a/lib/Bar.js
+++ b/lib/Bar.js
@@ -23,6 +23,9 @@ function Bar(options){
     // clear on finish ?
     this.clearOnComplete = options.clearOnComplete || false;
 
+    // stop on finish ?
+    this.stopOnComplete = options.stopOnComplete || false;
+
     // last drawn string - only render on change!
     this.lastDrawnString = null;
 
@@ -205,6 +208,9 @@ Bar.prototype.update = function(current){
     if (this.lastRedraw + this.throttleTime < Date.now()){
         this.calculateETA();
         this.render();
+    }
+    if (this.value >= this.getTotal() && this.stopOnComplete) {
+        this.stop();
     }
 };
 


### PR DESCRIPTION
It's not always practical to call `stop` manually when progress has completed, so add an option to automatically call `stop` when the value of the progress bar hits the configured total value.