### PR TITLE
add forceRedraw option and ability to update payload without updating progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Multi Bar Mode
 
 ![Demo](assets/multibar.png)
 
-### Example ### 
+### Example ###
 
 ```js
 const _cliProgress = require('cli-progress');
@@ -220,6 +220,7 @@ The following options can be changed
 - `noTTYOutput` (type:boolean) - enable scheduled output to notty streams - e.g. redirect to files (default: false)
 - `notTTYSchedule` (type:int) - set the output schedule/interval for notty output in `ms` (default: 2000ms)
 - `emptyOnZero` (type:boolean) - display progress bars with 'total' of zero(0) as empty, not full (default: false)
+- `forceRedraw` (type:boolean) - trigger redraw on every frame even if progress remains the same; can be useful if progress bar gets overwritten by other concurrent writes to the terminal (default: false)
 
 Bar Formatting
 -----------------------------------
@@ -269,7 +270,7 @@ function myFormatter(options, params, payload){
         return '# ' + _colors.grey(payload.task) + '   ' + _colors.green(params.value + '/' + params.total) + ' --[' + bar + ']-- ';
     }else{
         return '# ' + payload.task + '   ' + _colors.yellow(params.value + '/' + params.total) + ' --[' + bar + ']-- ';
-    }    
+    }
 }
 
 const opt = {

--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ Starts the progress bar and set the total and initial value
 
 ### ::update() ###
 
-Sets the current progress value and optionally the payload with values of custom tokens as a second parameter
+Sets the current progress value and optionally the payload with values of custom tokens as a second parameter. To update payload only, set currentValue to `null`.
 
 ```js
-<instance>.update(currentValue:int [, payload:object = {}]);
+<instance>.update([currentValue:int [, payload:object = {}]]);
 ```
 
 ### ::increment() ###

--- a/lib/generic-bar.js
+++ b/lib/generic-bar.js
@@ -67,9 +67,12 @@ module.exports = class GenericBar{
         // format string
         const s = this.formatter(this.options, params, this.payload);
 
+        const forceRedraw = this.options.forceRedraw
+            // force redraw in notty-mode!
+            || (this.options.noTTYOutput && !this.terminal.isTTY());
+
         // string changed ? only trigger redraw on change!
-        // force redraw in notty-mode!
-        if (this.lastDrawnString != s || (this.options.noTTYOutput && !this.terminal.isTTY())){
+        if (forceRedraw || this.lastDrawnString != s){
             // set cursor to start of line
             this.terminal.cursorTo(0, null);
 

--- a/lib/generic-bar.js
+++ b/lib/generic-bar.js
@@ -46,7 +46,7 @@ module.exports = class GenericBar{
         // calculate the normalized current progress
         let progress = (this.value/this.total);
 
-        // handle NaN Errors caused by total=0. Set to complete in this case 
+        // handle NaN Errors caused by total=0. Set to complete in this case
         if (isNaN(progress)){
             progress = (this.options && this.options.emptyOnZero) ? 0.0 : 1.0;
         }
@@ -81,7 +81,7 @@ module.exports = class GenericBar{
 
             // clear to the right from cursor
             this.terminal.clearRight();
-            
+
             // store string
             this.lastDrawnString = s;
 
@@ -115,11 +115,13 @@ module.exports = class GenericBar{
 
     // update the bar value
     update(current, payload){
-        // update value
-        this.value = current;
-        
-        // add new value; recalculate eta
-        this.eta.update(Date.now(), current, this.total);
+        if (typeof current !== 'undefined' && current !== null) {
+            // update value
+            this.value = current;
+
+            // add new value; recalculate eta
+            this.eta.update(Date.now(), current, this.total);
+        }
 
         // merge payload
         const payloadData = payload || {};

--- a/lib/options.js
+++ b/lib/options.js
@@ -66,6 +66,9 @@ module.exports = {
         // emptyOnZero - false
         _options.emptyOnZero = mergeOption(opt.emptyOnZero, false);
 
+        // force bar redraw even if progress did not change
+        _options.forceRedraw = mergeOption(opt.forceRedraw, false);
+
         return _options;
     },
 


### PR DESCRIPTION
New `forceRedraw` option forces render update to redraw the bar even if string has not changed. This is useful in situations when another piece of code is writing to the terminal (e.g. outputting logs while progress bar is running). Without this option progress bar disappears until the next progress update. When a lot of things get logged it makes progress bar virtually invisible.

It also adds ability to update payload information without touching the progress value itself. Can be useful when progress bar gets updated in multiple different scopes at the same time.