### PR TITLE
Fix documentation for the `stream` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ The following options can be changed
 
 - `format` (type:string|function) - progress bar output format @see format section
 - `fps` (type:float) - the maximum update rate (default: 10)
-- `stream` (type:stream) - output stream to use (default: `process.stdout`)
+- `stream` (type:stream) - output stream to use (default: `process.stderr`)
 - `stopOnComplete` (type:boolean) - automatically call `stop()` when the value reaches the total (default: false)
 - `clearOnComplete` (type:boolean) - clear the progress bar on complete / `stop()` call (default: false)
 - `barsize` (type:int) - the length of the progress bar in chars (default: 40)


### PR DESCRIPTION
The `stream` option defaults to `process.stderr` but is shown in the `README` as defaulting to `process.stdout`.