### PR TITLE
Fix progress bar jitter due to percentage

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -34,7 +34,7 @@ module.exports = function defaultFormatter(options, params, payload){
     b = b.substr(0, options.barsize);
 
     // calculate progress in percent
-    const percentage =  String(Math.round(params.progress*100)).padEnd(2);
+    const percentage =  String(Math.round(params.progress*100)).padEnd(3);
 
     // calculate elapsed time
     const elapsedTime = Math.round((Date.now() - params.startTime)/1000);

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -34,7 +34,7 @@ module.exports = function defaultFormatter(options, params, payload){
     b = b.substr(0, options.barsize);
 
     // calculate progress in percent
-    const percentage =  Math.round(params.progress*100) + '';
+    const percentage =  String(Math.round(params.progress*100)).padEnd(2);
 
     // calculate elapsed time
     const elapsedTime = Math.round((Date.now() - params.startTime)/1000);


### PR DESCRIPTION
The `{percentage}` formatting placeholder is either 1, 2 or 3 characters long. Because of this, the text on its right side is jumping one character to the right once the percentage reaches 10%.

This PR removes this jitter by padding the `{percentage}` placeholder to its right.