### PR TITLE
Allows log without disturbing progress bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,14 @@ Stops the all progress bars
 <instance>.stop();
 ```
 
+### ::log(args) ###
+
+Renders log into output (like: `console.log`) before progress bars, without disturbing them
+
+```js
+<instance>.log("Operation started!");
+```
+
 Options
 -----------------------------------
 

--- a/lib/multi-bar.js
+++ b/lib/multi-bar.js
@@ -26,7 +26,28 @@ module.exports = class MultiBar{
 
         // update interval
         this.schedulingRate = (this.terminal.isTTY() ? this.options.throttleTime : this.options.notTTYSchedule);
+
+        // console logs to append
+        this.logArgs = [];
     }
+
+    log() {
+        this.logArgs.push(arguments);
+    }
+
+    renderLogs() {
+        if(this.logArgs.length > 0) {
+            while(this.logArgs.length > 0) {
+                const toRender = this.logArgs.shift();
+                this.terminal.cursorTo(0, null);
+                this.terminal.write([...toRender].join(' '));
+                this.terminal.clearRight();
+                this.terminal.write('\n');
+                this.terminal.clearRight();
+            }
+        }
+    }
+    
 
     // add a new bar to the stack
     create(total, startValue, payload){
@@ -101,6 +122,8 @@ module.exports = class MultiBar{
         // reset cursor
         this.terminal.cursorRelativeReset();
 
+        this.renderLogs();
+
         // update each bar
         for (let i=0; i< this.bars.length; i++){
             // add new line ?
@@ -173,5 +196,7 @@ module.exports = class MultiBar{
             // new line on complete
             this.terminal.newline();
         }
+
+        this.renderLogs();
     }
 }


### PR DESCRIPTION
Using console.log together with cli-progress while progress bars are running disturbs bars and make log contents disappear under rendered bars.

This enhancement adds `log` method on MultiBar which blends nicely with standard rendering pipeline of progress bars.