### PR TITLE
Added beforeUpdateRendering and afterStop callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ The following options can be changed
 - `notTTYSchedule` (type:int) - set the output schedule/interval for notty output in `ms` (default: 2000ms)
 - `emptyOnZero` (type:boolean) - display progress bars with 'total' of zero(0) as empty, not full (default: false)
 - `forceRedraw` (type:boolean) - trigger redraw on every frame even if progress remains the same; can be useful if progress bar gets overwritten by other concurrent writes to the terminal (default: false)
+- `beforeUpdateRendering` (type:function) - if given, this callback is called for each update of MultiBar, just before bars are rendered (default: false)
+- `afterStop` (type:function) - if given, this callback is called after stop of MultiBar (default: false)
 
 Bar Formatting
 -----------------------------------

--- a/lib/multi-bar.js
+++ b/lib/multi-bar.js
@@ -101,6 +101,11 @@ module.exports = class MultiBar{
         // reset cursor
         this.terminal.cursorRelativeReset();
 
+        // allow custom output before rendering all bars
+        if (this.options.beforeUpdateRendering !== false) {
+            this.options.beforeUpdateRendering(this.terminal);
+        }
+
         // update each bar
         for (let i=0; i< this.bars.length; i++){
             // add new line ?
@@ -172,6 +177,11 @@ module.exports = class MultiBar{
 
             // new line on complete
             this.terminal.newline();
+        }
+
+        // allow custom output/cleanup after stop
+        if (this.options.afterStop !== false) {
+            this.options.afterStop(this.terminal);
         }
     }
 }

--- a/lib/options.js
+++ b/lib/options.js
@@ -69,6 +69,12 @@ module.exports = {
         // force bar redraw even if progress did not change
         _options.forceRedraw = mergeOption(opt.forceRedraw, false);
 
+        // callback before rendering bars in update method, gets terminal as first argument (terminal => {})
+        _options.beforeUpdateRendering = mergeOption(opt.beforeUpdateRendering, false);
+
+        // callback after stop, gets terminal as first argument (terminal => {})
+        _options.afterStop = mergeOption(opt.afterStop, false);
+
         return _options;
     },
 


### PR DESCRIPTION
Added `beforeUpdateRendering` and `afterStop` callbacks to options, that allow user-side extensions of multi-bar