### PR TITLE
chore(increment): Handle the use case when increment value is not passed, but payload is

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ b1.start(200, 0, {
 b1.increment();
 b1.update(20);
 
+// increment and update speed
+b1.increment({ speed: '42 kbps' });
+
 // stop the bar
 b1.stop();
 ```

--- a/lib/generic-bar.js
+++ b/lib/generic-bar.js
@@ -158,8 +158,13 @@ module.exports = class GenericBar extends _EventEmitter{
     }
 
     // update the bar value
-    increment(step, payload){
-        step = step || 1;
+    increment(step = 1, payload = {}){
+        // handle the use case when `step` is omitted but payload is passed
+        if (typeof step === 'object') {
+            step = 1;
+            payload = step;
+        }
+
         this.update(this.value + step, payload);
     }
 


### PR DESCRIPTION
Right now, if I do something like: 

```javascript
b1.increment({ foo: 'bar' })
```

This breaks the progress bar.

 It'd be nice if we could pass a payload to increment, without explicitly specifying the increment step. 